### PR TITLE
fix: allow parsing of service version strings returned by windows

### DIFF
--- a/autoupdate_endpoints.go
+++ b/autoupdate_endpoints.go
@@ -61,7 +61,9 @@ func StringToVersion(verStr string) (*Version, error) {
 	if versionCompiler.MatchString(verStr) {
 		matches := versionCompiler.FindStringSubmatch(verStr)
 
-		versionParts, err := parseAllInts(matches[1:])
+		// parse only the relevant part (so the last version string is ignored and does
+		// not return any errors)
+		versionParts, err := parseAllInts(matches[1:4])
 		if err != nil {
 			return nil, fmt.Errorf("Error parsing version string '%s': %v", verStr, err)
 		}

--- a/autoupdate_endpoints_test.go
+++ b/autoupdate_endpoints_test.go
@@ -28,6 +28,18 @@ func TestWindowsServiceVersionParsing(t *testing.T) {
 
 }
 
+func TestWindowsServiceVersionParsingNonNumeric(t *testing.T) {
+
+	ver, err := StringToVersion("1.8.177-rc2")
+	assert(t, err == nil, "Should parse the version string")
+
+	assertInt(t, ver.Major, 1, "Parse: Bad major version")
+	assertInt(t, ver.Minor, 8, "Parse: Bad minor version")
+	assertInt(t, ver.Patch, 177, "Parse: Bad patch version")
+
+	assertString(t, ver.String(), "v1.8.177", "Version stringification mismatch")
+
+}
 func TestVersionComparison(t *testing.T) {
 	v1, _ := StringToVersion("v1.3.2")
 	v2, _ := StringToVersion("v1.3.3")


### PR DESCRIPTION
So the watchdog service can use the `StringToLicense()` function to parse windows versions
