### PR TITLE
fix: update the epoch to be greater then the most recent travis build…

### DIFF
--- a/rpm-build/palette-insight-server.spec
+++ b/rpm-build/palette-insight-server.spec
@@ -30,7 +30,7 @@
 
 Name: palette-insight-server
 Version: %version
-Epoch: 1
+Epoch: 400
 Release: %buildrelease
 Summary: Palette Insight Server
 AutoReqProv: no


### PR DESCRIPTION
As the previous RPM-s used the travis build number as Epoch, so after we have switched to use travis build numbers for incremental build numbers, we need to increment the epoch to be larger then the last build with a non-1 epoch.
