### PR TITLE
fix: double-addition of file info column for serverlog files

### DIFF
--- a/lib/gzip_helpers.go
+++ b/lib/gzip_helpers.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"crypto/rand"
+
 	"github.com/Sirupsen/logrus"
 )
 
@@ -103,6 +105,18 @@ func (g *GzippedFileWriterWithTemp) Md5() []byte {
 func (g *GzippedFileWriterWithTemp) GetFileName() string {
 	// get the file hash
 	return g.GetFileNameForMd5(fmt.Sprintf("%032x", g.Md5()))
+}
+
+// Returns the output filename by using random bytes instead of a hash
+func (g *GzippedFileWriterWithTemp) GetRandomFileName() string {
+	buf := make([]byte, 16)
+	// Read some random bytes
+	if _, err := rand.Read(buf); err != nil {
+		// if there is an error, revert back to the less safe stuff
+		buf = RandStringBytes(16)
+	}
+	// generate a random 32 char string
+	return g.GetFileNameForMd5(fmt.Sprintf("%032x", buf))
 }
 
 // Returns the output filename by using the supplied md5 string and the original output filename

--- a/lib/helpers.go
+++ b/lib/helpers.go
@@ -574,3 +574,15 @@ func unescapeUnicodePoints(r io.Reader, w io.Writer) error {
 
 	return fmt.Errorf("Unreachable code reached.")
 }
+
+// Helper to add the pre- and postfixes to each written row
+func surroundWith(row []string, prefix, postfix string) []string {
+	outLen := len(row) + 2
+	o := make([]string, outLen)
+	o[0] = prefix
+	o[outLen-1] = postfix
+	copy(o[1:], row[0:])
+	return o
+}
+
+const GpfdistPostfixTsFormat = "2006-01-02 15:04:05"

--- a/lib/helpers_test.go
+++ b/lib/helpers_test.go
@@ -2,6 +2,7 @@ package insight_server
 
 import (
 	"bytes"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -41,4 +42,9 @@ func TestUnicodeUnescape(t *testing.T) {
 	}
 
 	assertString(t, `(\"CalQtrOffset\" <= 0) AND (\"CalQtrOffset\" >= -4)`, string(outStr.Bytes()), "Mismattched strign")
+}
+
+func TestSurroundWith(t *testing.T) {
+	row := surroundWith([]string{"a", "b", "c"}, "foo", "bar")
+	assert(t, reflect.DeepEqual(row, []string{"foo", "a", "b", "c", "bar"}), "mismatch")
 }


### PR DESCRIPTION
- cleanup of gzip output writer code
- fixes issue of accidentally using 64 bytes long random string instead of the regular 32
