### PR TITLE
Fix: warnings piling up in nginx/errors.log

### DIFF
--- a/rpm-build/etc/nginx/conf.d/palette-insight-server.conf
+++ b/rpm-build/etc/nginx/conf.d/palette-insight-server.conf
@@ -7,7 +7,8 @@ server {
     ssl_certificate           /etc/palette-insight-certs/cert.crt;
     ssl_certificate_key       /etc/palette-insight-certs/cert.key;
 
-    client_max_body_size 200m;
+    client_body_buffer_size 20m;
+    client_max_body_size 20m;
 
     ssl on;
     ssl_session_cache  builtin:1000  shared:SSL:10m;


### PR DESCRIPTION
The warnings were there because the buffer size for the request was small and the contents were pumped into a temporary file. This filled up more than 1.5Gb of space per day on netflix (but compressed down to a few hundred kB/day because of the repetition)
