### PR TITLE
Use filepath package for paths on the file system

### DIFF
--- a/lib/autoupdate_endpoints.go
+++ b/lib/autoupdate_endpoints.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"regexp"
 	"strconv"
 
@@ -124,7 +124,7 @@ func getLatestAgentVersion(updatePath string) (*UpdateVersion, error) {
 	if err != nil {
 		return nil, err
 	}
-	packageMd5, err := computeMd5(path.Join(updatePath, "agent"))
+	packageMd5, err := computeMd5(filepath.Join(updatePath, "agent"))
 	if err != nil {
 		return nil, err
 	}

--- a/lib/commands_endpoint.go
+++ b/lib/commands_endpoint.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -27,7 +27,7 @@ var lastCommand AgentCommand
 const CommandsFileName = "commands.json"
 
 func saveFileName() string {
-	return path.Join(baseDir, CommandsFileName)
+	return filepath.Join(baseDir, CommandsFileName)
 }
 
 // Saves the list of current commands with timestamps

--- a/lib/config_endpoint.go
+++ b/lib/config_endpoint.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 )
 
@@ -32,7 +31,7 @@ func checkHostnameParam(w http.ResponseWriter, req *http.Request) (string, error
 }
 
 func DoesConfigExist(hostname string) bool {
-	destinationPath := path.Join(AgentConfigsFolder, hostname, AgentConfigFileName)
+	destinationPath := filepath.Join(AgentConfigsFolder, hostname, AgentConfigFileName)
 	if _, err := os.Stat(destinationPath); os.IsNotExist(err) {
 		return false
 	}
@@ -47,7 +46,7 @@ func ServeConfig(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	sourcePath := path.Join(AgentConfigsFolder, hostname, AgentConfigFileName)
+	sourcePath := filepath.Join(AgentConfigsFolder, hostname, AgentConfigFileName)
 	http.ServeFile(w, req, sourcePath)
 }
 
@@ -68,8 +67,8 @@ func UploadConfig(w http.ResponseWriter, req *http.Request) {
 	defer uploadFile.Close()
 
 	// Make sure that the destination folder exists
-	destinationPath := path.Join(AgentConfigsFolder, hostname, AgentConfigFileName)
-	err = os.MkdirAll(path.Dir(destinationPath), 0777)
+	destinationPath := filepath.Join(AgentConfigsFolder, hostname, AgentConfigFileName)
+	err = os.MkdirAll(filepath.Dir(destinationPath), 0777)
 	if err != nil {
 		WriteResponse(w, http.StatusInternalServerError,
 			fmt.Sprintf("Failed to store uploaded config file! Error: %v", err))

--- a/lib/gzip_helpers.go
+++ b/lib/gzip_helpers.go
@@ -8,10 +8,8 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
-
 	"crypto/rand"
 
 	"github.com/Sirupsen/logrus"
@@ -127,7 +125,7 @@ func (g *GzippedFileWriterWithTemp) GetFileNameForMd5(fileMd5 string) string {
 
 	// the output is in the originally intended directory,
 	// but with our new filename containing the hash of the file
-	return filepath.ToSlash(path.Join(
+	return filepath.ToSlash(filepath.Join(
 		filepath.Dir(g.filePath),
 		fmt.Sprintf("%s.%s.gz",
 			SanitizeName(strings.TrimSuffix(baseFilename, baseFileExt)),

--- a/lib/maxid_endpoint.go
+++ b/lib/maxid_endpoint.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 
@@ -83,7 +82,7 @@ type fileMaxIdBackend struct {
 
 // gets the file name of a tables maxid file
 func (m *fileMaxIdBackend) getFileName(username, tableName string) string {
-	return path.Join(m.basePath, SanitizeName(username), SanitizeName(tableName))
+	return filepath.Join(m.basePath, SanitizeName(username), SanitizeName(tableName))
 }
 
 func (m *fileMaxIdBackend) SaveMaxId(username, tableName, maxid string) error {


### PR DESCRIPTION
...  instead of path package, because it might lead to mixed slash and backslash separators on Windows systems
